### PR TITLE
"GridFieldBulkImageUpload" is deprecated, use "GridFieldBulkUpload" clas...

### DIFF
--- a/code/PhotoGalleryPage.php
+++ b/code/PhotoGalleryPage.php
@@ -25,9 +25,9 @@ class PhotoGalleryPage extends Page {
 		}
 	    
 		$gridFieldConfig = GridFieldConfig_RecordEditor::create();
-		$gridFieldConfig->addComponent(new GridFieldBulkImageUpload());
+		$gridFieldConfig->addComponent(new GridFieldBulkUpload());
 		$gridFieldConfig->addComponent(new GridFieldGalleryTheme('Image'));
-		$gridFieldConfig->getComponentByType('GridFieldBulkImageUpload')->setConfig('folderName', "Managed/PhotoGalleries/".$this->ID."-".$this->URLSegment);
+		$gridFieldConfig->getComponentByType('GridFieldBulkUpload')->setConfig('folderName', "Managed/PhotoGalleries/".$this->ID."-".$this->URLSegment);
 		
 		$gridFieldConfig->removeComponentsByType('GridFieldPaginator');
 		$gridFieldConfig->addComponent(new GridFieldSortableRows('SortOrder'));


### PR DESCRIPTION
This morning I discovered that GridFieldBulkImageUpload has been deprecated. Using GridFieldBulkUpload makes the notices in the CMS go away.
